### PR TITLE
add cmd to detect failed tests

### DIFF
--- a/cmd/junit.go
+++ b/cmd/junit.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/flanksource/build-tools/pkg/junit"
 	"github.com/spf13/cobra"
@@ -23,6 +24,25 @@ func init() {
 				return err
 			}
 			fmt.Println(results.GenerateMarkdown())
+
+			return nil
+		},
+	})
+	Junit.AddCommand(&cobra.Command{
+		Use:     "passfail",
+		Aliases: []string{"pf"},
+		Short: "Print result summary for JUnit test and set exit code to 1 if there are failed tests.",
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			results, err := junit.ParseJunitResultFiles(args...)
+			if err != nil {
+				return err
+			}
+			fmt.Println(results.String())
+			if results.Failed > 0 {
+				os.Exit(1)
+			}
 
 			return nil
 		},


### PR DESCRIPTION
add a cmd to fail CI tests if JUnit results have failures:

```
philip@silent:/code/flanksource/build-tools$ go run main.go junit passfail ./results.xml && echo $?
46 tests, 22 passed, 1 failed, 23 skipped
exit status 1
philip@silent:/code/flanksource/build-tools$ go run main.go junit passfail ./results.xml && echo $?
46 tests, 23 passed, 0 failed, 23 skipped
0
```