### PR TITLE
Add goss based docker image verification

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,7 +1,7 @@
 name: Publish Binary
 on:
   push:
-    tags:
+    tags: "*"
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Publish Docker
 on:
   push:
-    tags:
+    tags: "*"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -1,0 +1,39 @@
+name: Test Docker
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Build image for testing
+        id: build_image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: localhost:5000/flanksource/build-tools:test
+      - name: Install goss
+        run: |
+          mkdir ~/bin
+          export GOSS_DST=~/bin
+          export PATH=$PATH:~/bin
+          curl -fsSL https://goss.rocks/install | sh
+          goss -version
+      - name: Execute goss test
+        run: |
+          mkdir -p ./reports/goss
+          export PATH=$PATH:~/bin
+          export GOSS_FILES_STRATEGY=cp
+          export GOSS_FILES_PATH=test 
+          export GOSS_OPTS="$GOSS_OPTS --format junit"
+          dgoss run --entrypoint=./test/fakeentry.sh localhost:5000/flanksource/build-tools:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,10 @@ RUN  apt-get update && apt-get install -y xz-utils && \
     wget -nv -O upx.tar.xz https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz; tar xf upx.tar.xz; mv upx-3.96-amd64_linux/upx /usr/bin
 RUN GOOS=linux GOARCH=amd64 make setup linux compress
 
-
 FROM ubuntu:bionic
 COPY --from=builder /app/.bin/build-tools /bin/
 ARG SYSTOOLS_VERSION=3.6
-
+COPY ./ ./
 RUN apt-get update && \
   apt-get install -y  genisoimage gnupg-agent curl apt-transport-https wget jq git sudo npm python-setuptools python3-pip python3-dev build-essential xz-utils ca-certificates unzip zip software-properties-common && \
   add-apt-repository ppa:longsleep/golang-backports && \
@@ -39,17 +38,17 @@ RUN wget -nv https://github.com/meterup/github-release/releases/download/v0.7.5/
   bzip2 -d linux-amd64-github-release.bz2 && \
   chmod +x linux-amd64-github-release && \
   mv linux-amd64-github-release /usr/local/bin/github-release
-RUN npm install -g netlify-cli now gh
+RUN npm install -g npm@latest && hash -r && npm install node --reinstall-packages-from=node
+RUN npm install -g netlify-cli gh
 RUN go get github.com/mjibson/esc
 RUN mv /root/go/bin/esc /usr/local/bin/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-RUN wget -nv --output-file govc.gz https://github.com/vmware/govmomi/releases/download/v0.23.0/govc_linux_amd64.gz && \
+RUN wget -nv -O govc.gz https://github.com/vmware/govmomi/releases/download/v0.23.0/govc_linux_amd64.gz && \
     gunzip govc.gz && \
     chmod +x govc && \
     mv govc /usr/local/bin/
-
 #ENTRYPOINT [ "/bin/build-tools" ]
 
 

--- a/test/fakeentry.sh
+++ b/test/fakeentry.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sleep 600

--- a/test/goss.yaml
+++ b/test/goss.yaml
@@ -1,0 +1,74 @@
+package:
+  build-essential:
+    installed: true
+  ca-certificates:
+    installed: true
+  genisoimage:
+    installed: true
+  git:
+    installed: true
+  golang-go:
+    installed: true
+  python3-dev:
+    installed: true
+  sops:
+    installed: true
+  systools:
+    installed: true
+  zip:
+    installed: true
+command:
+  command -v build-tools:
+    exit-status: 0
+    stdout:
+    - \/bin/build-tools
+    stderr: []
+    timeout: 10000
+  command -v esc:
+    exit-status: 0
+    stdout:
+    - \/usr/local/bin/esc
+    stderr: []
+    timeout: 10000
+  command -v expenv:
+    exit-status: 0
+    stdout:
+    - \/usr/bin/expenv
+    stderr: []
+    timeout: 10000
+  command -v gh:
+    exit-status: 0
+    stdout:
+    - \/usr/local/bin/gh
+    stderr: []
+    timeout: 10000
+  command -v github-release:
+    exit-status: 0
+    stdout:
+    - \/usr/local/bin/github-release
+    stderr: []
+    timeout: 10000
+  command -v gojsontoyaml:
+    exit-status: 0
+    stdout:
+    - \/usr/bin/gojsontoyaml
+    stderr: []
+    timeout: 10000
+  command -v govc:
+    exit-status: 0
+    stdout:
+    - \/usr/local/bin/govc
+    stderr: []
+    timeout: 10000
+  command -v netlify:
+    exit-status: 0
+    stdout:
+    - \/usr/local/bin/netlify
+    stderr: []
+    timeout: 10000
+  command -v upx:
+    exit-status: 0
+    stdout:
+    - \/usr/bin/upx
+    stderr: []
+    timeout: 10000


### PR DESCRIPTION
- Update github actions
  - Install goss to runner
  - separate build and publish steps
- Update Docker image
  - update npm version, default Ubuntu 18.04 version no longer supported