### PR TITLE
GitHub runner and additional Docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,28 @@
+### Github Workflows
+
+It is recommended that forks of this repo disable github actions if they do not
+wish to also publish build artefacts
+
+#### bump.yaml
+
+The bump workflow automatically tags new commits to master with a monotincally
+increasing version number
+
+#### binary.yaml
+
+The binary workflow is triggered on a tag push (usually as a result of the bump
+workflow).  It generates the build-tools binary and publishes it as a GitHub
+release.
+
+#### docker.yaml
+
+The docker workflow is also triggered by a tag push, and generates a docker
+image containing the build-tools utility as well as a number of other useful
+executables.  The image is published to the [Flanksource
+Dockerhub](https://hub.docker.com/r/flanksource/build-tools)
+
+#### dockertest.yaml
+
+The dockertest workflow runs on pull request, building the docker image and
+verifying that is is created correctly using
+[goss](https://github.com/aelsabbahy/goss)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,9 @@ release.
 The docker workflow is also triggered by a tag push, and generates a docker
 image containing the build-tools utility as well as a number of other useful
 executables.  The image is published to the [Flanksource
-Dockerhub](https://hub.docker.com/r/flanksource/build-tools)
+Dockerhub](https://hub.docker.com/r/flanksource/build-tools). The generated
+image can be used as a [k8s self-hosted github
+runner](https://github.com/summerwind/actions-runner-controller)
 
 #### dockertest.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN  apt-get update && apt-get install -y xz-utils && \
     wget -nv -O upx.tar.xz https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz; tar xf upx.tar.xz; mv upx-3.96-amd64_linux/upx /usr/bin
 RUN GOOS=linux GOARCH=amd64 make setup linux compress
 
-FROM ubuntu:bionic
+FROM summerwind/actions-runner:v2.273.4
+USER root
 COPY --from=builder /app/.bin/build-tools /bin/
 ARG SYSTOOLS_VERSION=3.6
 COPY ./ ./
@@ -49,6 +50,7 @@ RUN wget -nv -O govc.gz https://github.com/vmware/govmomi/releases/download/v0.2
     gunzip govc.gz && \
     chmod +x govc && \
     mv govc /usr/local/bin/
-#ENTRYPOINT [ "/bin/build-tools" ]
+USER runner:runner
+# Do not override entrypoint, the one specified in the summerwind image is required
 
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ release: setup linux darwin compress
 
 .PHONY: setup
 setup:
-	which esc 2>&1 > /dev/null || go get -u github.com/mjibson/esc
-	which github-release 2>&1 > /dev/null || go get github.com/aktau/github-release
+	command -v esc 2>&1 > /dev/null || go get -u github.com/mjibson/esc
+	command -v github-release 2>&1 > /dev/null || go get github.com/aktau/github-release
 
 .PHONY: build
 build:
@@ -49,6 +49,11 @@ install:
 .PHONY: docker
 docker:
 	docker build ./ -t $(NAME)
+
+.PHONY: test
+test: docker
+	command -v dgoss 2>&1 > /dev/null || test/installgoss.sh
+	GOSS_FILES_PATH=test dgoss run --entrypoint=./test/fakeentry.sh $(NAME)
 
 #.PHONY: serve-docs
 #serve-docs:

--- a/test/goss.yaml
+++ b/test/goss.yaml
@@ -72,3 +72,11 @@ command:
     - \/usr/bin/upx
     stderr: []
     timeout: 10000
+file:
+  /runner/entrypoint.sh:
+    exists: true
+    mode: "0755"
+    owner: root
+    group: root
+    filetype: file
+    contains: []

--- a/test/installgoss.sh
+++ b/test/installgoss.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+mkdir -p ~/bin
+export GOSS_DST=~/bin
+curl -fsSL https://goss.rocks/install | sh
+goss -version
+


### PR DESCRIPTION
- add some basic docs regarding workflow behaviour
- add a test make target (currently only tests the docker build process)
- Change docker base image to summerwind action runner image to allow the build-tools image to be used a base for self-hosted runners